### PR TITLE
Add base agent, task, and tool classes

### DIFF
--- a/src/crewai/agents/base.py
+++ b/src/crewai/agents/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Any
+
+from ..tasks.base import Task
+from ..tools.base import Tool
+
+
+class Agent(ABC):
+    """Abstract base class representing an autonomous agent."""
+
+    def __init__(self, role: str, goal: str, tools: Optional[List[Tool]] = None) -> None:
+        """Initialize the agent.
+
+        Parameters
+        ----------
+        role: str
+            The role assigned to the agent.
+        goal: str
+            The agent's overall objective.
+        tools: list[Tool] | None
+            Optional list of tools this agent can utilize.
+        """
+        self.role = role
+        self.goal = goal
+        self.tools: List[Tool] = tools or []
+
+    @abstractmethod
+    def act(self, task: Task) -> Any:
+        """Execute the given task and return a result."""
+        raise NotImplementedError

--- a/src/crewai/tasks/base.py
+++ b/src/crewai/tasks/base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Task(ABC):
+    """Generic task interface that agents can perform."""
+
+    def __init__(self, description: str) -> None:
+        self.description = description
+
+    @abstractmethod
+    def execute(self) -> Any:
+        """Run the task and return a result."""
+        raise NotImplementedError

--- a/src/crewai/tools/base.py
+++ b/src/crewai/tools/base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Tool(ABC):
+    """Base class for pluggable tools available to agents."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def use(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the tool and return a result."""
+        raise NotImplementedError

--- a/tests/test_instantiation.py
+++ b/tests/test_instantiation.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+# Ensure the src directory is importable
+sys.path.insert(0, os.path.abspath("src"))
+
+from crewai.agents.base import Agent
+from crewai.tasks.base import Task
+from crewai.tools.base import Tool
+
+
+class DummyTool(Tool):
+    def use(self, *args, **kwargs):
+        return "used"
+
+
+class DummyTask(Task):
+    def execute(self):
+        return "task done"
+
+
+class DummyAgent(Agent):
+    def act(self, task: Task):
+        return task.execute()
+
+
+def test_instantiation():
+    tool = DummyTool(name="dummy")
+    task = DummyTask(description="demo")
+    agent = DummyAgent(role="tester", goal="demo", tools=[tool])
+
+    assert agent.role == "tester"
+    assert agent.goal == "demo"
+    assert agent.tools[0].use() == "used"
+    assert agent.act(task) == "task done"


### PR DESCRIPTION
## Summary
- implement abstract `Agent`, `Task`, and `Tool` classes under `src/crewai`
- add minimal unit tests showing instantiation of these classes

## Testing
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml is not a file`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d84bb6808321a94e6b2bad39a4ba